### PR TITLE
Added key and parent accessors to database.reference.

### DIFF
--- a/src/Firebase/Database/Reference.elm
+++ b/src/Firebase/Database/Reference.elm
@@ -1,7 +1,9 @@
 effect module Firebase.Database.Reference
     where { subscription = MySub }
     exposing
-        ( child
+        ( key
+        , parent
+        , child
         , set
         , update
         , updateMulti
@@ -21,6 +23,16 @@ import Task exposing (Task)
 import Firebase.Database.Types exposing (Reference, Snapshot, Query, OnDisconnect)
 import Firebase.Errors exposing (Error)
 import Native.Database.Reference
+
+
+key : Reference -> String
+key =
+    Native.Database.Reference.key
+
+
+parent : Reference -> Reference
+parent =
+    Native.Database.Reference.parent
 
 
 child : String -> Reference -> Reference

--- a/src/Native/Database/Reference.js
+++ b/src/Native/Database/Reference.js
@@ -14,6 +14,20 @@ var _pairshaped$elm_firebase$Native_Database_Reference = function () { // eslint
   // Reference methods
 
 
+  var key = function (refModel) {
+    debug(".child", path, refModel)
+    var reference = refModel.reference().child(path)
+
+    return reference.key
+  }
+
+  var parent = function (refModel) {
+    debug(".child", path, refModel)
+    var reference = refModel.reference().child(path)
+
+    return reference.parent
+  }
+
   var child = function (path, refModel) {
     debug(".child", path, refModel)
     var reference = refModel.reference().child(path)
@@ -175,6 +189,8 @@ var _pairshaped$elm_firebase$Native_Database_Reference = function () { // eslint
 
 
   return {
+    "key": key,
+    "parent": parent,
     "child": F2(child),
     "set": F2(set),
     "update": F2(update),


### PR DESCRIPTION
## What

 - Added `Firebase.Database.Reference.key`
 - Added `Firebase.Database.Reference.parent`

## Why

 - `.key` is useful when doing a `.push`
 - `.parent` because I needed it for another project.

## GIF

![](https://media.giphy.com/media/h6vizUOPyM88M/giphy.gif)