### PR TITLE
Support firebase when initialized outside of elm

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,5 +1,5 @@
 ## Credits
 
  - [@tilmans](https://github.com/tilmans) - Early adopter, and guinea pig for all that code I should have tested and haven't yet.
-
+ - [@ucode](https://github.com/ucode) - Brought the new firebase environment initialization to my attention.
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Then you can add elm-firebase to your elm-package.json like so:
 ```
 {
   "dependencies": {
-    "pairshaped/elm-firebase": "0.0.12 <= v < 1.0.0"
+    "pairshaped/elm-firebase": "0.0.13 <= v < 1.0.0"
   },
   "dependency-sources": {
     "pairshaped/elm-firebase": {
       "url": "https://github.com/pairshaped/elm-firebase",
-      "ref": "master"
+      "ref": "v0.0.13"
     }
   }
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.0.11",
+    "version": "0.0.13",
     "summary": "Firebase bindings for elm",
     "repository": "https://github.com/pairshaped/elm-firebase.git",
     "license": "BSD3",

--- a/examples/kitchenSink/src/Main.elm
+++ b/examples/kitchenSink/src/Main.elm
@@ -138,6 +138,7 @@ type Msg
     | SignInAnonymously
     | SignedIn (Result Error User)
     | SignOut
+    | GetApp
     | NoOp ()
 
 
@@ -238,6 +239,13 @@ update msg model =
                 , Task.perform NoOp (Firebase.Authentication.signOut auth)
                 )
 
+        GetApp ->
+            let
+                _ =
+                    Debug.log "Firebase app" (Firebase.app ())
+            in
+                update (NoOp ()) model
+
         NoOp _ ->
             ( model
             , Cmd.none
@@ -272,6 +280,9 @@ view model =
             ]
         , div [] [ text ("Collection query = " ++ (toString model.collection)) ]
         , viewSignIn model.currentUser
+        , button
+            [ onClick GetApp ]
+            [ text "Check console for current app" ]
         ]
 
 

--- a/src/Firebase.elm
+++ b/src/Firebase.elm
@@ -4,6 +4,7 @@ module Firebase
         , Config
         , sdkVersion
         , apps
+        , app
         , init
         , initWithName
         , deinit
@@ -17,7 +18,7 @@ module Firebase
 @docs App, Config
 
 # App methods
-@docs init, initWithName, deinit, name, options
+@docs app, init, initWithName, deinit, name, options
 
 # Helpers
 @docs sdkVersion, apps
@@ -76,6 +77,34 @@ apps : () -> List App
 apps =
     Native.Firebase.apps
 
+
+{-| Get the currently initialized app if there is one
+
+Maps to `firebase.app`
+-}
+
+app : () -> Maybe App
+app =
+    Native.Firebase.app
+
+
+{-| Find an app with a given name
+
+To get the default app:
+
+```
+app : Maybe Firebase.App
+app =
+    Firebase.getAppByName "[DEFAULT]"
+```
+
+Does not map to a Firebase method, it's just a convenience
+-}
+getAppByName : String -> Maybe App
+getAppByName appName =
+    apps ()
+        |> List.filter (\app -> (name app) == appName)
+        |> List.head
 
 
 -- App Methods

--- a/src/Native/Firebase.js
+++ b/src/Native/Firebase.js
@@ -29,6 +29,29 @@ var _pairshaped$elm_firebase$Native_Firebase = function () { // eslint-disable-l
     return _elm_lang$core$Native_List.fromArray(firebase.apps)
   }
 
+  var app = function (dummy) {
+    debug("Firebase.app", dummy)
+
+    try {
+      var app = firebase.app()
+
+      if (app) {
+        return {
+          ctor: "Just",
+          _0: {
+            ctor: "App",
+            app: function () { return app }
+          }
+        }
+      }
+    } catch (e) {
+      // No op
+      // firebase.app() can throw an error if an app hasn't been initialized.
+    }
+
+    return { ctor: "Nothing" }
+  }
+
 
   // Firebase.App methods
 
@@ -91,6 +114,7 @@ var _pairshaped$elm_firebase$Native_Firebase = function () { // eslint-disable-l
   return {
     "sdkVersion": sdkVersion,
     "apps": apps,
+    "app": app,
     "init": init,
     "initWithName": F2(initWithName),
     "deinit": deinit,


### PR DESCRIPTION
## What

 - Added `Firebase.app : () -> Maybe Firebase.App` to get the current app if it has already been initialized.
 - Added `Firebase.getAppByName : String -> Maybe Firebase.App` to find an app by it's name. Typically only useful when there are multiple firebase apps active in one project (probably rare).

## Why

 - Resolves #23 
 - Adds support for new firebase environment-based initialization.

## GIF

![](https://media3.giphy.com/media/LiVRcDxJiktJ6/giphy.gif)