### PR TITLE
Expose `projectId` as a `Firebase.Config` field

### DIFF
--- a/src/Firebase.elm
+++ b/src/Firebase.elm
@@ -51,6 +51,7 @@ type alias Config =
     , databaseURL : String
     , storageBucket : String
     , messagingSenderId : String
+    , projectId : String
     }
 
 


### PR DESCRIPTION
Currently if you use the auto initialization mechanism there is no way to get the project id via this library. This data is already exposed by the Firebase API, but the elm type alias does not expose the field. The project ID is useful if you are utilizing Firebase functions to get your function endpoint

```
functionsEndpoint : Firebase.Config -> String
functionsEndpoint config =
  "https://us-central-" ++ config.projectId ++ ".cloudfunctions.net"
```