### PR TITLE
Safe Listener Events

### DIFF
--- a/examples/kitchenSink/public/index.html
+++ b/examples/kitchenSink/public/index.html
@@ -11,7 +11,7 @@
         You will need:
         <ol>
           <li>A browser that supports <a href="https://developer.mozilla.org/en/docs/Web/API/Fetch_API#Browser_compatibility">fetch()</a></li>
-          <li>A json file describing your firebase config, see <a href="firebase.json.example">the example structure</a>.<br/>When you create a firebase database, there will be a butotn on the dashboard "Add Firebase to your web app", just copy the values of the config variable, and make sure you add quotes around the object keys for proper json support.</li>
+          <li>A json file describing your firebase config, see <a href="firebase.json.example">the example structure</a>.<br/>When you create a firebase database, there will be a button on the dashboard "Add Firebase to your web app", just copy the values of the config variable, and make sure you add quotes around the object keys for proper json support.</li>
         </ol>
       </div>
     </div>

--- a/examples/kitchenSink/src/Main.elm
+++ b/examples/kitchenSink/src/Main.elm
@@ -12,7 +12,7 @@ import Firebase.Database
 import Firebase.Database.Query
 import Firebase.Database.Reference
 import Firebase.Database.Snapshot
-import Firebase.Database.Types exposing (Database, Query, Reference, Snapshot)
+import Firebase.Database.Types exposing (Database, Query, Reference, Snapshot, Event(..))
 import Firebase.Authentication
 import Firebase.Authentication.User
 import Firebase.Authentication.Types exposing (Auth, User)
@@ -29,13 +29,13 @@ main =
                 subscribeToReference : List (Sub Msg)
                 subscribeToReference =
                     if model.subscription then
-                        [ Firebase.Database.Reference.on "value" model.subRef SubscriptionChange ]
+                        [ Firebase.Database.Reference.on Value model.subRef SubscriptionChange ]
                     else
                         []
 
                 subscribeToQuery : List (Sub Msg)
                 subscribeToQuery =
-                    [ Firebase.Database.Query.on "value" model.subQuery CollectionQuery ]
+                    [ Firebase.Database.Query.on Value model.subQuery CollectionQuery ]
             in
                 Sub.batch
                     (List.append subscribeToReference subscribeToQuery)
@@ -122,7 +122,7 @@ init flags =
                 |> Firebase.Database.ref (Just "demo")
     in
         ( model
-        , Task.perform ReadDemo (Firebase.Database.Reference.once "value" ref)
+        , Task.perform ReadDemo (Firebase.Database.Reference.once Value ref)
         )
 
 

--- a/examples/writer/src/Main.elm
+++ b/examples/writer/src/Main.elm
@@ -11,7 +11,7 @@ import Firebase.Errors exposing (Error)
 import Firebase.Database
 import Firebase.Database.Reference
 import Firebase.Database.Snapshot
-import Firebase.Database.Types exposing (Database, Reference, Snapshot)
+import Firebase.Database.Types exposing (Database, Reference, Snapshot, Event(..))
 import Firebase.Authentication
 import Firebase.Authentication.Types exposing (User)
 
@@ -26,7 +26,7 @@ main =
             case model.reference of
                 Just ref ->
                     Sub.batch
-                        [ Firebase.Database.Reference.on "value" ref UpdatedSnapshot
+                        [ Firebase.Database.Reference.on Value ref UpdatedSnapshot
                         ]
 
                 Nothing ->

--- a/src/Firebase/Database.elm
+++ b/src/Firebase/Database.elm
@@ -2,6 +2,7 @@ module Firebase.Database
     exposing
         ( init
         , ref
+        , eventString
         )
 
 {-| Firebase.Database handles database initialization and getting an initial reference
@@ -12,7 +13,7 @@ module Firebase.Database
 
 import Firebase
 import Native.Database
-import Firebase.Database.Types exposing (Database, Reference)
+import Firebase.Database.Types exposing (Database, Reference, Event(..))
 
 
 {-| Given a Firebase.App, return its Database object
@@ -31,3 +32,17 @@ Maps to `firebase.app.App#database()`
 ref : Maybe String -> Database -> Reference
 ref =
     Native.Database.ref
+
+eventString : Event -> String
+eventString event =
+    case event of
+        Value ->
+            "value"
+        ChildAdded ->
+            "child_added"
+        ChildMoved ->
+            "child_moved"
+        ChildChanged ->
+            "child_changed"
+        ChildRemoved ->
+            "child_removed"

--- a/src/Firebase/Database/Query.elm
+++ b/src/Firebase/Database/Query.elm
@@ -34,7 +34,8 @@ For more information on all of these functions, see [the firebase docs](https://
 
 import Json.Encode
 import Task exposing (Task)
-import Firebase.Database.Types exposing (Query, Reference, Snapshot)
+import Firebase.Database exposing (eventString)
+import Firebase.Database.Types exposing (Query, Reference, Snapshot, Event(..))
 import Native.Database.Query
 
 
@@ -158,36 +159,36 @@ limitToLast =
 
 Event types include:
 
- - `"value"` - get the value of the objects matching the query.
- - `"child_added"` - get the first new child in the current query.
- - `"child_changed"` - get the first modified child in the current query.
- - `"child_removed"` - get the first child modified to by null in the current query.
- - `"child_moved"` - get the object where the key has changed in the current query.
+ - `Value` - get the value of the objects matching the query.
+ - `ChileAdded` - get the first new child in the current query.
+ - `ChileChanged` - get the first modified child in the current query.
+ - `ChildRemoved` - get the first child modified by null in the current query.
+ - `ChildMoved` - get the object where the key has changed in the current query.
 
 Most likely, with one-off queries using `.once`, you'll be using `"value"`.
 
 See [firebase.database.Query#once](https://firebase.google.com/docs/reference/js/firebase.database.Query#once)
 -}
-once : String -> Query -> Task x Snapshot
-once =
-    Native.Database.Query.once
+once : Event -> Query -> Task x Snapshot
+once event =
+    Native.Database.Query.once (eventString event)
 
 
 {-| Given an event type and query, return a subscription to this query
 
 Even types include:
 
- - `"value"` - watch all values matching this query
- - `"child_added"` - watch for all new children added matching this query
- - `"child_changed"` - watch for all modified children matching this query
- - `"child_removed"` - watch for all children that stop matching this query or are deleted
- - `"child_moved"` - watch for all children with modified keys matching this query
+ - `Value` - get the value of the objects matching the query.
+ - `ChileAdded` - get the first new child in the current query.
+ - `ChileChanged` - get the first modified child in the current query.
+ - `ChildRemoved` - get the first child modified to null in the current query.
+ - `ChildMoved` - get the object where the key has changed in the current query.
 
 See [firebase.database.Query#once](https://firebase.google.com/docs/reference/js/firebase.database.Query#once)
 -}
-on : String -> Query -> (Snapshot -> msg) -> Sub msg
+on : Event -> Query -> (Snapshot -> msg) -> Sub msg
 on event query tagger =
-    subscription (MySub event query tagger)
+    subscription (MySub (eventString event) query tagger)
 
 
 

--- a/src/Firebase/Database/Reference.elm
+++ b/src/Firebase/Database/Reference.elm
@@ -21,7 +21,8 @@ effect module Firebase.Database.Reference
 
 import Json.Encode
 import Task exposing (Task)
-import Firebase.Database.Types exposing (Reference, Snapshot, Query, OnDisconnect)
+import Firebase.Database exposing (eventString)
+import Firebase.Database.Types exposing (Reference, Snapshot, Query, OnDisconnect, Event)
 import Firebase.Errors exposing (Error)
 import Native.Database.Reference
 
@@ -101,14 +102,14 @@ isEqual =
     Native.Database.Reference.isEqual
 
 
-once : String -> Reference -> Task x Snapshot
-once =
-    Native.Database.Reference.once
+once : Event -> Reference -> Task x Snapshot
+once event =
+    Native.Database.Reference.once (eventString event)
 
 
-on : String -> Reference -> (Snapshot -> msg) -> Sub msg
+on : Event -> Reference -> (Snapshot -> msg) -> Sub msg
 on event reference tagger =
-    subscription (MySub event reference tagger)
+    subscription (MySub (eventString event) reference tagger)
 
 
 

--- a/src/Firebase/Database/Types.elm
+++ b/src/Firebase/Database/Types.elm
@@ -1,16 +1,5 @@
 module Firebase.Database.Types exposing (..)
 
-{-| Temporary documentation to enable testing.
-
-# Types
-@docs Database
-
-@docs Reference
-
---}
-
-{-| Somrthisg
---}
 type Database
     = Database
 

--- a/src/Firebase/Database/Types.elm
+++ b/src/Firebase/Database/Types.elm
@@ -1,6 +1,16 @@
 module Firebase.Database.Types exposing (..)
 
+{-| Temporary documentation to enable testing.
 
+# Types
+@docs Database
+
+@docs Reference
+
+--}
+
+{-| Somrthisg
+--}
 type Database
     = Database
 
@@ -19,3 +29,16 @@ type Snapshot
 
 type OnDisconnect
     = OnDisconnect
+
+{-| Designates a realtime database event.
+
+See [firebase.database.Reference#on](https://firebase.google.com/docs/reference/node/firebase.database.Reference#on)
+for more information on event types.
+--}
+type Event
+    = Value
+    | ChildAdded
+    | ChildMoved
+    | ChildChanged
+    | ChildRemoved
+


### PR DESCRIPTION
Looking once again to eliminate a class of potential runtime errors. The logic behind this change follows the 'making impossible states impossible' philosophy. The idea is that the listener events for the various `once` and `on` functions can be only one of 5 values ("value", "child_added", "child_moved", "child_changed", "child_removed").

The current library requires these exact strings and passes them off to the firebase library. The problem is that if the user of elm-firebase typos one of those strings you have introduced a runtime error!

This change moves those event variables from a string to an elm union type.

```elm
type Event
  = Value
  | ChildAdded
  | ChildMoved
  | ChildChanged
  | ChildRemoved
```

The benefits of this change are that it eliminates a potential runtime error. The downside is that you take 1 step further from the official firebase API.