### PR TITLE
Fix invalid ref in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Then you can add elm-firebase to your elm-package.json like so:
   "dependency-sources": {
     "pairshaped/elm-firebase": {
       "url": "https://github.com/pairshaped/elm-firebase",
-      "ref": "v0.0.13"
+      "ref": "0.0.13"
     }
   }
 }


### PR DESCRIPTION
elm-github-install gave following error:
`error: pathspec 'v0.0.13' did not match any file(s) known to git.`

change to 0.0.13 fix the issue.