### PR TITLE
fix: Firebase.Database.Snapshot.exists function does not exists

### DIFF
--- a/src/Firebase/Database/Snapshot.elm
+++ b/src/Firebase/Database/Snapshot.elm
@@ -22,7 +22,7 @@ child =
 
 exists : Snapshot -> Bool
 exists =
-    Native.Database.exists
+    Native.Database.Snapshot.exists
 
 
 exportVal : Snapshot -> Json.Decode.Value

--- a/src/Native/Authentication.js
+++ b/src/Native/Authentication.js
@@ -52,11 +52,9 @@ var _pairshaped$elm_firebase$Native_Authentication = function () { // eslint-dis
     debug(".currentUser", authModel)
     var auth = authModel.auth()
 
-    return userToModel(
-      auth.currentUser
-        ? { ctor: "Just", _0: auth.currentUser }
-        : { ctor: "Nothing }"}
-    )
+    return  auth.currentUser
+        ? { ctor: "Just", _0: userToModel(auth.currentUser) }
+        : { ctor: "Nothing"}
   }
 
 

--- a/src/Native/Database/Snapshot.js
+++ b/src/Native/Database/Snapshot.js
@@ -42,8 +42,6 @@ var _pairshaped$elm_firebase$Native_Database_Snapshot = function () { // eslint-
     var snapshot = snapshotModel.snapshot()
 
     return snapshot.exists()
-      ? { ctor: "True" }
-      : { ctor: "False" }
   }
 
   var exportVal = function (snapshotModel) {


### PR DESCRIPTION
1. Map Firebase.Database.Snapshot.exists to correct native function
2. Return boolean result from .exists() directly. Returning `{ ctor: "False" }` evaluates to True in elm 0.18.0